### PR TITLE
Remove the com.google.protobuf bundle from the feature and the category

### DIFF
--- a/features/org.eclipse.wst.jsdt.feature/feature.xml
+++ b/features/org.eclipse.wst.jsdt.feature/feature.xml
@@ -118,11 +118,4 @@
           version="0.0.20160315.qualifier"
           unpack="false"/>
 
-    <plugin
-          id="com.google.protobuf"
-          download-size="0"
-          install-size="0"
-          version="2.4.0.qualifier"
-          unpack="false"/>
-
 </feature>

--- a/site/category.xml
+++ b/site/category.xml
@@ -41,7 +41,6 @@
     <feature id="org.eclipse.wst.jsdt.chromium.debug.feature.source"><category name="wtp.incubation.sources"/></feature>
 
     <bundle id="com.google.gson"/>
-    <bundle id="com.google.protobuf"/>
 
      <category-def name="wtp" label="Web Tools Platform (WTP)"><description>These features provide functionality with the executable code only and are recommended for most users.</description></category-def>
      <category-def name="wtp.sdk" label="Web Tools Platform SDK (WTP SDK)"><description>These features provide functionality with the executable code and the source code and are recommended for those extending or debugging WTP.</description></category-def>


### PR DESCRIPTION
- There are no uses of the one Java package this bundle provides