### PR TITLE
Fixing the Parser Config ES6 to ES6_OR_ES7

### DIFF
--- a/bundles/org.eclipse.wst.jsdt.core/src/org/eclipse/wst/jsdt/internal/compiler/closure/ClosureCompiler.java
+++ b/bundles/org.eclipse.wst.jsdt.core/src/org/eclipse/wst/jsdt/internal/compiler/closure/ClosureCompiler.java
@@ -109,7 +109,7 @@ public class ClosureCompiler {
 	}
 
 	public JavaScriptUnit parse() {
-		Config config = new Config(com.google.javascript.jscomp.parsing.parser.Parser.Config.Mode.ES6);
+		Config config = new Config(com.google.javascript.jscomp.parsing.parser.Parser.Config.Mode.ES6_OR_ES7);
 		SourceFile source = getSourceFile(); 
 		ErrorCollector errorCollector = new  ErrorCollector(source.name);
 		Parser parser = new Parser(config, errorCollector, source);


### PR DESCRIPTION
ES3,
ES5,
ES6_OR_ES7,
ES8_OR_GREATER

These are the only available mode in com.google.javascript, so i changed ES6 to ES6_OR_ES7, i am getting below error due to this
java.lang.NoSuchFieldError: com/google/javascript/jscomp/parsing/parser/Parser$Config$Mode.ES6