### PR TITLE
Link source panel made interactive

### DIFF
--- a/bundles/org.eclipse.wst.jsdt.ui/src/org/eclipse/wst/jsdt/internal/ui/wizards/buildpaths/SourceContainerWorkbookPage.java
+++ b/bundles/org.eclipse.wst.jsdt.ui/src/org/eclipse/wst/jsdt/internal/ui/wizards/buildpaths/SourceContainerWorkbookPage.java
@@ -342,6 +342,7 @@ public class SourceContainerWorkbookPage extends BuildPathBasePage {
 				CPListElement newElement= new CPListElement(fCurrJProject, IIncludePathEntry.CPE_SOURCE);
 				AddSourceFolderWizard wizard= newLinkedSourceFolderWizard(newElement, fFoldersList.getElements(), "", true); //$NON-NLS-1$
 				OpenBuildPathWizardAction action= new OpenBuildPathWizardAction(wizard);
+				action.setShell(getShell());
 				action.run();
 			} else if (index==IDX_ADDJAR) {
 				libentries= openJarFileDialog(null);


### PR DESCRIPTION
The `Link Source` panel in the `Client-Side Java Script` > `Include Path` > `Source` is made interactive.

Fixes : https://github.com/eclipse-jsdt/webtools.jsdt/issues/8