### PR TITLE
Replace deprecated File.toURL()

### DIFF
--- a/bundles/org.eclipse.wst.jsdt.ui/src/org/eclipse/wst/jsdt/internal/ui/javadocexport/JavadocWizard.java
+++ b/bundles/org.eclipse.wst.jsdt.ui/src/org/eclipse/wst/jsdt/internal/ui/javadocexport/JavadocWizard.java
@@ -396,7 +396,7 @@ public class JavadocWizard extends Wizard implements IExportWizard {
 		if (fOpenInBrowser) {
 			try {
 				IPath indexFile= fDestination.append("index.html"); //$NON-NLS-1$
-				URL url= indexFile.toFile().toURL();
+				URL url= indexFile.toFile().toURI().toURL();
 				OpenBrowserUtil.open(url, display, getWindowTitle());
 			} catch (MalformedURLException e) {
 				JavaScriptPlugin.log(e);

--- a/bundles/org.eclipse.wst.jsdt.ui/src/org/eclipse/wst/jsdt/internal/ui/preferences/JavadocConfigurationBlock.java
+++ b/bundles/org.eclipse.wst.jsdt.ui/src/org/eclipse/wst/jsdt/internal/ui/preferences/JavadocConfigurationBlock.java
@@ -346,7 +346,7 @@ public class JavadocConfigurationBlock {
 				File indexFile= new File(folder, "index.html"); //$NON-NLS-1$
 				if (indexFile.isFile()) {
 					if (MessageDialog.openConfirm(fShell, fTitle, fValidMessage)) { 
-						spawnInBrowser(indexFile.toURL());
+						spawnInBrowser(indexFile.toURI().toURL());
 					}
 					return;
 				}
@@ -629,7 +629,7 @@ public class JavadocConfigurationBlock {
 		String result= dialog.open();
 		if (result != null) {
 			try {
-				URL url= new File(result).toURL();
+				URL url= new File(result).toURI().toURL();
 				return url.toExternalForm();
 			} catch (MalformedURLException e) {
 				JavaScriptPlugin.log(e);
@@ -740,7 +740,7 @@ public class JavadocConfigurationBlock {
 				buf.append("platform:/resource").append(encodeExclamationMarks(res.getFullPath().toString())); //$NON-NLS-1$
 			}
 		} else {
-			buf.append(encodeExclamationMarks(new File(jarLoc).toURL().toExternalForm()));
+			buf.append(encodeExclamationMarks(new File(jarLoc).toURI().toURL().toExternalForm()));
 		}
 		buf.append('!');
 		if (innerPath.length() > 0) {


### PR DESCRIPTION
`java.io.File.toURL()` is deprecated and marked for removal.This PR replaces it with `file.toURI().toURL()`, where toURL() is called on a `java.net.URI` instance, which is not deprecated and handles encoding correctly.







